### PR TITLE
Kotlin 1.8 support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -17,9 +18,9 @@ subprojects {
 
     pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
         tasks.withType<KotlinCompile>().configureEach {
-            kotlinOptions {
-                jvmTarget = "1.8"
-                freeCompilerArgs = freeCompilerArgs + listOf("-progressive")
+            compilerOptions {
+                jvmTarget.set(JvmTarget.JVM_1_8)
+                freeCompilerArgs.add("-progressive")
             }
         }
     }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -46,9 +46,17 @@ dependencies {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    // https://github.com/tschuchortdev/kotlin-compile-testing/pull/63
-    kotlinOptions.freeCompilerArgs += "-Xno-optimized-callable-references"
-    kotlinOptions.freeCompilerArgs += "-Xskip-runtime-version-check"
+    val isTest = name.contains("test", ignoreCase = true)
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            // https://github.com/tschuchortdev/kotlin-compile-testing/pull/63
+            "-Xno-optimized-callable-references",
+            "-Xskip-runtime-version-check",
+        )
+        if (isTest) {
+            freeCompilerArgs.add("-opt-in=org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi")
+        }
+    }
 }
 
 tasks.withType<Jar>().configureEach {

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt
@@ -15,7 +15,6 @@ import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.Services
-import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.kotlin.util.ServiceLoaderLite
 import java.io.File
 import java.io.OutputStream
@@ -134,17 +133,6 @@ abstract class AbstractKotlinCompilation<A : CommonCompilerArguments> internal c
 
     // Directory for input source files
     protected val sourcesDir get() = workingDir.resolve("sources")
-
-    protected inline fun <reified T> CommonCompilerArguments.trySetDeprecatedOption(optionSimpleName: String, value: T) {
-        try {
-            this.javaClass.getMethod(JvmAbi.setterName(optionSimpleName), T::class.java).invoke(this, value)
-        } catch (e: ReflectiveOperationException) {
-            throw IllegalArgumentException(
-                "The deprecated option $optionSimpleName is no longer available in the kotlin version you are using",
-                e
-            )
-        }
-    }
 
     protected fun commonArguments(args: A, configuration: (args: A) -> Unit): A {
         args.pluginClasspaths = pluginClasspaths.map(File::getAbsolutePath).toTypedArray()

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
 import org.jetbrains.kotlin.cli.js.K2JSCompiler
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.Services
@@ -49,10 +50,23 @@ abstract class AbstractKotlinCompilation<A : CommonCompilerArguments> internal c
      */
     var pluginClasspaths: List<File> = emptyList()
 
-    /**
-     * Compiler plugins that should be added to the compilation
-     */
+    @Deprecated(
+        "Use componentRegistrars instead",
+        ReplaceWith("componentRegistrars"),
+        DeprecationLevel.ERROR
+    )
     var compilerPlugins: List<ComponentRegistrar> = emptyList()
+
+    /**
+     * Legacy [ComponentRegistrar] plugins that should be added to the compilation.
+     */
+    @Deprecated("Migrate to ComponentPluginRegistrar and use componentPluginRegistrars instead")
+    var componentRegistrars: List<ComponentRegistrar> = emptyList()
+
+    /**
+     * [CompilerPluginRegistrars][CompilerPluginRegistrar] that should be added to the compilation.
+     */
+    var compilerPluginRegistrars: List<CompilerPluginRegistrar> = emptyList()
 
     /**
      * Commandline processors for compiler plugins that should be added to the compilation
@@ -195,7 +209,8 @@ abstract class AbstractKotlinCompilation<A : CommonCompilerArguments> internal c
             MainComponentRegistrar.ThreadLocalParameters(
                 listOf(),
                 KaptOptions.Builder(),
-                compilerPlugins,
+                componentRegistrars,
+                compilerPluginRegistrars,
                 supportsK2
             )
         )
@@ -216,9 +231,9 @@ abstract class AbstractKotlinCompilation<A : CommonCompilerArguments> internal c
                      be found by the Kotlin compiler's service loader. We add it only when the user has actually given
                      us ComponentRegistrar instances to be loaded by the MainComponentRegistrar because the experimental
                      K2 compiler doesn't support plugins yet. This way, users of K2 can prevent MainComponentRegistrar
-                     from being loaded and crashing K2 by setting both [compilerPlugins] and [commandLineProcessors] to
+                     from being loaded and crashing K2 by setting both [componentRegistrars] and [commandLineProcessors] to
                      the emptyList. */
-                    if (compilerPlugins.isNotEmpty() || commandLineProcessors.isNotEmpty())
+                    if (componentRegistrars.isNotEmpty() || commandLineProcessors.isNotEmpty())
                         arrayOf(getResourcesPath())
                     else emptyArray()
         }

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt
@@ -10,16 +10,15 @@ import org.jetbrains.kotlin.cli.common.arguments.validateArguments
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
 import org.jetbrains.kotlin.cli.js.K2JSCompiler
-import org.jetbrains.kotlin.cli.jvm.plugins.ServiceLoaderLite
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.Services
 import org.jetbrains.kotlin.load.java.JvmAbi
+import org.jetbrains.kotlin.util.ServiceLoaderLite
 import java.io.File
 import java.io.OutputStream
 import java.io.PrintStream
-import java.lang.reflect.InvocationTargetException
-import java.lang.reflect.ReflectPermission
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -29,6 +28,7 @@ import java.nio.file.Paths
  * functionality. Should not be used outside of this library as it is an
  * implementation detail.
  */
+@ExperimentalCompilerApi
 abstract class AbstractKotlinCompilation<A : CommonCompilerArguments> internal constructor() {
     /** Working directory for the compilation */
     var workingDir: File by default {
@@ -300,11 +300,11 @@ abstract class AbstractKotlinCompilation<A : CommonCompilerArguments> internal c
     internal val internalMessageStreamAccess: PrintStream get() = internalMessageStream
 }
 
+@ExperimentalCompilerApi
 internal fun convertKotlinExitCode(code: ExitCode) = when(code) {
     ExitCode.OK -> KotlinCompilation.ExitCode.OK
-    ExitCode.OOM_ERROR,
+    ExitCode.OOM_ERROR -> throw OutOfMemoryError("Kotlin compiler ran out of memory")
     ExitCode.INTERNAL_ERROR -> KotlinCompilation.ExitCode.INTERNAL_ERROR
     ExitCode.COMPILATION_ERROR -> KotlinCompilation.ExitCode.COMPILATION_ERROR
     ExitCode.SCRIPT_EXECUTION_ERROR -> KotlinCompilation.ExitCode.SCRIPT_EXECUTION_ERROR
-    ExitCode.OOM_ERROR -> throw OutOfMemoryError("Kotlin compiler ran out of memory")
 }

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KaptComponentRegistrar.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KaptComponentRegistrar.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.cli.jvm.config.JvmClasspathRoot
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
@@ -49,6 +50,7 @@ import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
 import org.jetbrains.kotlin.resolve.jvm.extensions.PartialAnalysisHandlerExtension
 import java.io.File
 
+@ExperimentalCompilerApi
 internal class KaptComponentRegistrar(
     private val processors: List<IncrementalProcessor>,
     private val kaptOptions: KaptOptions.Builder

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.JVMAssertionsMode
 import org.jetbrains.kotlin.config.JvmDefaultMode
 import org.jetbrains.kotlin.config.JvmTarget
@@ -44,6 +45,7 @@ typealias PluginId = String
 typealias OptionName = String
 typealias OptionValue = String
 
+@ExperimentalCompilerApi
 @Suppress("MemberVisibilityCanBePrivate")
 class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 	/** Arbitrary arguments to be passed to kapt */
@@ -125,9 +127,6 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 
 	/** Path to JSON file to dump Java to Kotlin declaration mappings */
 	var declarationsOutputPath: File? = null
-
-	/** Combine modules for source files and binary dependencies into a single module */
-	var singleModule: Boolean = false
 
 	/** Suppress the \"cannot access built-in declaration\" error (useful with -no-stdlib) */
 	var suppressMissingBuiltinsError: Boolean = false
@@ -355,8 +354,6 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 
 		if(declarationsOutputPath != null)
 			args.declarationsOutputPath = declarationsOutputPath!!.toString()
-
-		args.singleModule = singleModule
 
 		if(javacArguments.isNotEmpty())
 			args.javacArguments = javacArguments.toTypedArray()
@@ -705,6 +702,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
  * this.classpaths += previousResult.outputDirectory
  * ```
  */
+@ExperimentalCompilerApi
 fun KotlinCompilation.addPreviousResultToClasspath(
 	previousResult: KotlinCompilation.Result
 ): KotlinCompilation = apply {

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -94,7 +94,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 	var noParamAssertions: Boolean = false
 
 	/** Generate nullability assertions for non-null Java expressions */
-	@Deprecated("Removed in latest Kotlin version")
+	@Deprecated("Removed in Kotlinc, this does nothing now.")
 	var strictJavaNullabilityAssertions: Boolean? = null
 
 	/** Disable optimizations */
@@ -106,7 +106,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 	 *
 	 * {disable|enable}
 	 */
-	@Deprecated("Removed in latest Kotlin version")
+	@Deprecated("Removed in Kotlinc, this does nothing now.")
 	var constructorCallNormalizationMode: String? = null
 
 	/** Assert calls behaviour {always-enable|always-disable|jvm|legacy} */
@@ -122,11 +122,15 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 	var useTypeTable: Boolean = false
 
 	/** Allow Kotlin runtime libraries of incompatible versions in the classpath */
-	@Deprecated("Removed in latest Kotlin version")
+	@Deprecated("Removed in Kotlinc, this does nothing now.")
 	var skipRuntimeVersionCheck: Boolean? = null
 
 	/** Path to JSON file to dump Java to Kotlin declaration mappings */
 	var declarationsOutputPath: File? = null
+
+	/** Combine modules for source files and binary dependencies into a single module */
+	@Deprecated("Removed in Kotlinc, this does nothing now.")
+	var singleModule: Boolean = false
 
 	/** Suppress the \"cannot access built-in declaration\" error (useful with -no-stdlib) */
 	var suppressMissingBuiltinsError: Boolean = false
@@ -147,7 +151,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 	var supportCompatqualCheckerFrameworkAnnotations: String? = null
 
 	/** Do not throw NPE on explicit 'equals' call for null receiver of platform boxed primitive type */
-	@Deprecated("Removed in latest Kotlin version")
+	@Deprecated("Removed in Kotlinc, this does nothing now.")
 	var noExceptionOnExplicitEqualsForBoxedNull: Boolean? = null
 
 	/** Allow to use '@JvmDefault' annotation for JVM default method support.
@@ -332,16 +336,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 		args.noParamAssertions = noParamAssertions
 		args.noReceiverAssertions = noReceiverAssertions
 
-		// TODO: Remove after kotlin 1.6.30
-		if(strictJavaNullabilityAssertions != null)
-			args.trySetDeprecatedOption("strictJavaNullabilityAssertions", strictJavaNullabilityAssertions)
-
 		args.noOptimize = noOptimize
-
-		// TODO: Remove after kotlin 1.6.30
-		if(constructorCallNormalizationMode != null)
-			args.trySetDeprecatedOption("constructorCallNormalizationMode", constructorCallNormalizationMode)
-
 
 		if(assertionsMode != null)
 			args.assertionsMode = assertionsMode
@@ -371,16 +366,8 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 		if(scriptResolverEnvironment.isNotEmpty())
 			args.scriptResolverEnvironment = scriptResolverEnvironment.map { (key, value) -> "$key=\"$value\"" }.toTypedArray()
 
-		// TODO: Remove after kotlin 1.6.30
-		if(noExceptionOnExplicitEqualsForBoxedNull != null)
-			args.trySetDeprecatedOption("noExceptionOnExplicitEqualsForBoxedNull", noExceptionOnExplicitEqualsForBoxedNull)
-
-		// TODO: Remove after kotlin 1.6.30
-		if(skipRuntimeVersionCheck != null)
-			args.trySetDeprecatedOption("skipRuntimeVersionCheck", skipRuntimeVersionCheck)
-
-        args.javaPackagePrefix = javaPackagePrefix
-        args.suppressMissingBuiltinsError = suppressMissingBuiltinsError
+		args.javaPackagePrefix = javaPackagePrefix
+		args.suppressMissingBuiltinsError = suppressMissingBuiltinsError
 	}
 
 	/** Performs the 1st and 2nd compilation step to generate stubs and run annotation processors */

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -423,7 +423,8 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 				MainComponentRegistrar.ThreadLocalParameters(
 					annotationProcessors.map { IncrementalProcessor(it, DeclaredProcType.NON_INCREMENTAL, kaptLogger) },
 					kaptOptions,
-					compilerPlugins,
+					componentRegistrars,
+					compilerPluginRegistrars,
 					supportsK2,
 				)
 		)

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinJsCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinJsCompilation.kt
@@ -2,8 +2,10 @@ package com.tschuchort.compiletesting
 
 import org.jetbrains.kotlin.cli.common.arguments.K2JSCompilerArguments
 import org.jetbrains.kotlin.cli.js.K2JSCompiler
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import java.io.*
 
+@ExperimentalCompilerApi
 @Suppress("MemberVisibilityCanBePrivate")
 class KotlinJsCompilation : AbstractKotlinCompilation<K2JSCompilerArguments>() {
 
@@ -28,7 +30,7 @@ class KotlinJsCompilation : AbstractKotlinCompilation<K2JSCompilerArguments>() {
   var irDcePrintReachabilityInfo: Boolean = false
 
   /** Disables pre-IR backend */
-  var irOnly: Boolean = false
+  var irOnly: Boolean = true
 
   /** Specify a compilation module name for IR backend */
   var irModuleName: String? = null

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinJsCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinJsCompilation.kt
@@ -21,7 +21,7 @@ class KotlinJsCompilation : AbstractKotlinCompilation<K2JSCompilerArguments>() {
   var irProduceKlibFile: Boolean = false
 
   /** Generates JS file using IR backend. Also disables pre-IR backend */
-  var irProduceJs: Boolean = false
+  var irProduceJs: Boolean = true
 
   /** Perform experimental dead code elimination */
   var irDce: Boolean = false

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/MainCommandLineProcessor.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/MainCommandLineProcessor.kt
@@ -4,9 +4,11 @@ import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
 import org.jetbrains.kotlin.compiler.plugin.CliOption
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import java.util.*
 
+@ExperimentalCompilerApi
 @AutoService(CommandLineProcessor::class)
 internal class MainCommandLineProcessor : CommandLineProcessor {
     override val pluginId: String = Companion.pluginId

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/MainComponentRegistrar.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/MainComponentRegistrar.kt
@@ -13,62 +13,80 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+@file:Suppress("DEPRECATION")
 package com.tschuchort.compiletesting
 
 import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.base.kapt3.KaptOptions
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.kapt3.base.incremental.IncrementalProcessor
 
 @ExperimentalCompilerApi
-@AutoService(ComponentRegistrar::class)
-internal class MainComponentRegistrar : ComponentRegistrar {
+@AutoService(ComponentRegistrar::class, CompilerPluginRegistrar::class)
+internal class MainComponentRegistrar : ComponentRegistrar, CompilerPluginRegistrar() {
 
-    override val supportsK2: Boolean
-        get() = threadLocalParameters.get().supportsK2
+  override val supportsK2: Boolean
+    get() = getThreadLocalParameters("supportsK2")?.supportsK2 ?: false
 
-    override fun registerProjectComponents(project: MockProject, configuration: CompilerConfiguration) {
-        // Handle unset parameters gracefully because this plugin may be accidentally called by other tools that
-        // discover it on the classpath (for example the kotlin jupyter kernel).
-        if (threadLocalParameters.get() == null) {
-            System.err.println("WARNING: MainComponentRegistrar::registerProjectComponents accessed before thread local parameters have been set")
-            return
-        }
-
-        val parameters = threadLocalParameters.get()
-
-        /*
-        The order of registering plugins here matters. If the kapt plugin is registered first, then
-        it will be executed first and any changes made to the AST by later plugins won't apply to the
-        generated stub files and thus won't be visible to any annotation processors. So we decided
-        to register third-party plugins before kapt and hope that it works, although we don't
-        know for sure if that is the correct way.
-         */
-        parameters.compilerPlugins.forEach { componentRegistrar->
-            componentRegistrar.registerProjectComponents(project,configuration)
-        }
-
-        KaptComponentRegistrar(parameters.processors, parameters.kaptOptions)
-                .registerProjectComponents(project,configuration)
+  // Handle unset parameters gracefully because this plugin may be accidentally called by other tools that
+  // discover it on the classpath (for example the kotlin jupyter kernel).
+  private fun getThreadLocalParameters(caller: String): ThreadLocalParameters? {
+    val params = threadLocalParameters.get()
+    if (params == null) {
+      System.err.println("WARNING: ${MainComponentRegistrar::class.simpleName}::$caller accessed before thread local parameters have been set")
     }
 
-    companion object {
-        /** This compiler plugin is instantiated by K2JVMCompiler using
-         *  a service locator. So we can't just pass parameters to it easily.
-         *  Instead, we need to use a thread-local global variable to pass
-         *  any parameters that change between compilations
-         */
-        val threadLocalParameters: ThreadLocal<ThreadLocalParameters> = ThreadLocal()
+    return params
+  }
+
+  override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
+    val parameters = getThreadLocalParameters("registerExtensions") ?: return
+
+    parameters.compilerPluginRegistrar.forEach { componentRegistrar ->
+      with(componentRegistrar) {
+        registerExtensions(configuration)
+      }
+    }
+  }
+
+  // Legacy plugins
+  override fun registerProjectComponents(project: MockProject, configuration: CompilerConfiguration) {
+    val parameters = getThreadLocalParameters("registerProjectComponents") ?: return
+
+    /*
+     * The order of registering plugins here matters. If the kapt plugin is registered first, then
+     * it will be executed first and any changes made to the AST by later plugins won't apply to the
+     * generated stub files and thus won't be visible to any annotation processors. So we decided
+     * to register third-party plugins before kapt and hope that it works, although we don't
+     * know for sure if that is the correct way.
+     */
+    parameters.componentRegistrars.forEach { componentRegistrar ->
+      componentRegistrar.registerProjectComponents(project, configuration)
     }
 
-    data class ThreadLocalParameters(
-        val processors: List<IncrementalProcessor>,
-        val kaptOptions: KaptOptions.Builder,
-        val compilerPlugins: List<ComponentRegistrar>,
-        val supportsK2: Boolean,
-    )
+    KaptComponentRegistrar(parameters.processors, parameters.kaptOptions)
+      .registerProjectComponents(project, configuration)
+  }
+
+  companion object {
+    /*
+     * This compiler plugin is instantiated by K2JVMCompiler using
+     * a service locator. So we can't just pass parameters to it easily.
+     * Instead, we need to use a thread-local global variable to pass
+     * any parameters that change between compilations
+     */
+    val threadLocalParameters: ThreadLocal<ThreadLocalParameters> = ThreadLocal()
+  }
+
+  data class ThreadLocalParameters(
+    val processors: List<IncrementalProcessor>,
+    val kaptOptions: KaptOptions.Builder,
+    val componentRegistrars: List<ComponentRegistrar>,
+    val compilerPluginRegistrar: List<CompilerPluginRegistrar>,
+    val supportsK2: Boolean,
+  )
 }

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/MainComponentRegistrar.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/MainComponentRegistrar.kt
@@ -20,9 +20,11 @@ import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.base.kapt3.KaptOptions
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.kapt3.base.incremental.IncrementalProcessor
 
+@ExperimentalCompilerApi
 @AutoService(ComponentRegistrar::class)
 internal class MainComponentRegistrar : ComponentRegistrar {
 

--- a/core/src/test/kotlin/com/tschuchort/compiletesting/CompilerPluginsTest.kt
+++ b/core/src/test/kotlin/com/tschuchort/compiletesting/CompilerPluginsTest.kt
@@ -3,9 +3,8 @@ package com.tschuchort.compiletesting
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.atLeastOnce
 import com.nhaarman.mockitokotlin2.verify
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
-import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.Assert
 import org.junit.Test
 import org.mockito.Mockito
@@ -13,23 +12,25 @@ import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.element.TypeElement
 
-@OptIn(ExperimentalCompilerApi::class)
 class CompilerPluginsTest {
 
     @Test
     fun `when compiler plugins are added they get executed`() {
 
         val mockPlugin = Mockito.mock(ComponentRegistrar::class.java)
+        val fakeRegistrar = FakeCompilerPluginRegistrar()
 
         val result = defaultCompilerConfig().apply {
             sources = listOf(SourceFile.new("emptyKotlinFile.kt", ""))
-            compilerPlugins = listOf(mockPlugin)
+            componentRegistrars = listOf(mockPlugin)
+            compilerPluginRegistrars = listOf(fakeRegistrar)
             inheritClassPath = true
         }.compile()
 
         verify(mockPlugin, atLeastOnce()).registerProjectComponents(any(), any())
+        fakeRegistrar.assertRegistered()
 
-        Assertions.assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
@@ -62,13 +63,13 @@ class CompilerPluginsTest {
         val result = defaultCompilerConfig().apply {
             sources = listOf(jSource)
             annotationProcessors = listOf(annotationProcessor)
-            compilerPlugins = listOf(mockPlugin)
+            componentRegistrars = listOf(mockPlugin)
             inheritClassPath = true
         }.compile()
 
         verify(mockPlugin, atLeastOnce()).registerProjectComponents(any(), any())
 
-        Assertions.assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
@@ -77,11 +78,12 @@ class CompilerPluginsTest {
 
         val result = defaultJsCompilerConfig().apply {
             sources = listOf(SourceFile.new("emptyKotlinFile.kt", ""))
-            compilerPlugins = listOf(mockPlugin)
+            componentRegistrars = listOf(mockPlugin)
             inheritClassPath = true
         }.compile()
 
         verify(mockPlugin, atLeastOnce()).registerProjectComponents(any(), any())
-        Assertions.assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 }
+

--- a/core/src/test/kotlin/com/tschuchort/compiletesting/CompilerPluginsTest.kt
+++ b/core/src/test/kotlin/com/tschuchort/compiletesting/CompilerPluginsTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockitokotlin2.atLeastOnce
 import com.nhaarman.mockitokotlin2.verify
 import org.assertj.core.api.Assertions
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.Assert
 import org.junit.Test
 import org.mockito.Mockito
@@ -12,6 +13,7 @@ import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.element.TypeElement
 
+@OptIn(ExperimentalCompilerApi::class)
 class CompilerPluginsTest {
 
     @Test

--- a/core/src/test/kotlin/com/tschuchort/compiletesting/FakeCompilerPluginRegistrar.kt
+++ b/core/src/test/kotlin/com/tschuchort/compiletesting/FakeCompilerPluginRegistrar.kt
@@ -1,0 +1,21 @@
+package com.tschuchort.compiletesting
+
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.config.CompilerConfiguration
+
+class FakeCompilerPluginRegistrar(
+    override val supportsK2: Boolean = false,
+) : CompilerPluginRegistrar() {
+    private var isRegistered = false
+
+    override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
+        isRegistered = true
+    }
+
+    fun assertRegistered() {
+        if(!isRegistered) {
+            throw AssertionError("FakeCompilerPluginRegistrar was not registered")
+        }
+    }
+
+}

--- a/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
+++ b/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
@@ -7,6 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
 import org.jetbrains.kotlin.compiler.plugin.CliOption
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
@@ -18,6 +19,7 @@ import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.element.TypeElement
 
+@OptIn(ExperimentalCompilerApi::class)
 @Suppress("MemberVisibilityCanBePrivate")
 class KotlinCompilationTests {
 	@Rule @JvmField val temporaryFolder = TemporaryFolder()

--- a/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
+++ b/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
@@ -19,7 +19,6 @@ import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.element.TypeElement
 
-@OptIn(ExperimentalCompilerApi::class)
 @Suppress("MemberVisibilityCanBePrivate")
 class KotlinCompilationTests {
 	@Rule @JvmField val temporaryFolder = TemporaryFolder()
@@ -910,7 +909,7 @@ class KotlinCompilationTests {
 	fun `runs the K2 compiler without compiler plugins`() {
 		val result = defaultCompilerConfig().apply {
 			sources = listOf(SourceFile.kotlin("kSource.kt", "class KSource"))
-			compilerPlugins = emptyList()
+			componentRegistrars = emptyList()
 			pluginClasspaths = emptyList()
 			useK2 = true
 		}.compile()

--- a/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinJsCompilationTests.kt
+++ b/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinJsCompilationTests.kt
@@ -76,8 +76,8 @@ class KotlinJsCompilationTests {
 		assertThat(result.exitCode).isEqualTo(ExitCode.OK)
 		assertThat(result.compiledClassAndResourceFiles).hasSize(1)
 		val jsFile = result.compiledClassAndResourceFiles[0]
-		assertThat(jsFile.readText()).contains("package\$a.KSource = KSource;")
-		assertThat(jsFile.readText()).contains("package\$b.KSource = KSource_0;")
+		assertThat(jsFile.readText()).contains("function KSource() {")
+		assertThat(jsFile.readText()).contains("function KSource_0() {")
 	}
 
 	@Test

--- a/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinJsCompilationTests.kt
+++ b/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinJsCompilationTests.kt
@@ -13,7 +13,6 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
 
-@OptIn(ExperimentalCompilerApi::class)
 @Suppress("MemberVisibilityCanBePrivate")
 class KotlinJsCompilationTests {
 	@Rule @JvmField val temporaryFolder = TemporaryFolder()

--- a/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinJsCompilationTests.kt
+++ b/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinJsCompilationTests.kt
@@ -7,11 +7,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
 import org.jetbrains.kotlin.compiler.plugin.CliOption
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
 
+@OptIn(ExperimentalCompilerApi::class)
 @Suppress("MemberVisibilityCanBePrivate")
 class KotlinJsCompilationTests {
 	@Rule @JvmField val temporaryFolder = TemporaryFolder()

--- a/core/src/test/kotlin/com/tschuchort/compiletesting/TestUtils.kt
+++ b/core/src/test/kotlin/com/tschuchort/compiletesting/TestUtils.kt
@@ -2,8 +2,10 @@ package com.tschuchort.compiletesting
 
 import io.github.classgraph.ClassGraph
 import org.assertj.core.api.Assertions
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import java.io.File
 
+@OptIn(ExperimentalCompilerApi::class)
 fun defaultCompilerConfig(): KotlinCompilation {
     return KotlinCompilation( ).apply {
         inheritClassPath = false
@@ -14,6 +16,7 @@ fun defaultCompilerConfig(): KotlinCompilation {
     }
 }
 
+@OptIn(ExperimentalCompilerApi::class)
 fun defaultJsCompilerConfig(): KotlinJsCompilation {
     return KotlinJsCompilation( ).apply {
         inheritClassPath = false
@@ -24,14 +27,15 @@ fun defaultJsCompilerConfig(): KotlinJsCompilation {
 }
 
 
+@OptIn(ExperimentalCompilerApi::class)
 fun assertClassLoadable(compileResult: KotlinCompilation.Result, className: String): Class<*> {
-    try {
+    return try {
         val clazz = compileResult.classLoader.loadClass(className)
         Assertions.assertThat(clazz).isNotNull
-        return clazz
+        clazz
     }
     catch(e: ClassNotFoundException) {
-        return Assertions.fail<Nothing>("Class $className could not be loaded")
+        Assertions.fail<Nothing>("Class $className could not be loaded")
     }
 }
 

--- a/core/src/test/kotlin/com/tschuchort/compiletesting/TestUtils.kt
+++ b/core/src/test/kotlin/com/tschuchort/compiletesting/TestUtils.kt
@@ -5,9 +5,8 @@ import org.assertj.core.api.Assertions
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import java.io.File
 
-@OptIn(ExperimentalCompilerApi::class)
 fun defaultCompilerConfig(): KotlinCompilation {
-    return KotlinCompilation( ).apply {
+    return KotlinCompilation().apply {
         inheritClassPath = false
         correctErrorTypes = true
         verbose = true
@@ -16,7 +15,6 @@ fun defaultCompilerConfig(): KotlinCompilation {
     }
 }
 
-@OptIn(ExperimentalCompilerApi::class)
 fun defaultJsCompilerConfig(): KotlinJsCompilation {
     return KotlinJsCompilation( ).apply {
         inheritClassPath = false
@@ -27,7 +25,6 @@ fun defaultJsCompilerConfig(): KotlinJsCompilation {
 }
 
 
-@OptIn(ExperimentalCompilerApi::class)
 fun assertClassLoadable(compileResult: KotlinCompilation.Result, className: String): Class<*> {
     return try {
         val clazz = compileResult.classLoader.loadClass(className)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin = "1.8.0-Beta"
-ksp = "1.8.0-Beta-1.0.8"
+kotlin = "1.8.0"
+ksp = "1.8.0-RC2-1.0.8"
 
 [plugins]
 buildconfig = { id = "com.github.gmazzo.buildconfig", version = "3.1.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin = "1.7.22"
-ksp = "1.7.22-1.0.8"
+kotlin = "1.8.0-Beta"
+ksp = "1.8.0-Beta-1.0.8"
 
 [plugins]
 buildconfig = { id = "com.github.gmazzo.buildconfig", version = "3.1.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "1.8.0"
-ksp = "1.8.0-RC2-1.0.8"
+ksp = "1.8.0-1.0.8"
 
 [plugins]
 buildconfig = { id = "com.github.gmazzo.buildconfig", version = "3.1.0" }

--- a/ksp/build.gradle.kts
+++ b/ksp/build.gradle.kts
@@ -1,16 +1,26 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
-    kotlin("jvm")
-    alias(libs.plugins.mavenPublish)
+  kotlin("jvm")
+  alias(libs.plugins.mavenPublish)
 }
 
+tasks.withType<KotlinCompile>()
+  .matching { it.name.contains("test", ignoreCase = true) }
+  .configureEach {
+    compilerOptions {
+      freeCompilerArgs.add("-opt-in=org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi")
+    }
+  }
+
 dependencies {
-    compileOnly(libs.kotlin.compilerEmbeddable)
-    api(projects.core)
-    compileOnly(libs.ksp.api)
-    implementation(libs.ksp)
-    testImplementation(libs.ksp.api)
-    testImplementation(libs.kotlin.junit)
-    testImplementation(libs.mockito)
-    testImplementation(libs.mockitoKotlin)
-    testImplementation(libs.assertJ)
+  compileOnly(libs.kotlin.compilerEmbeddable)
+  api(projects.core)
+  compileOnly(libs.ksp.api)
+  implementation(libs.ksp)
+  testImplementation(libs.ksp.api)
+  testImplementation(libs.kotlin.junit)
+  testImplementation(libs.mockito)
+  testImplementation(libs.mockitoKotlin)
+  testImplementation(libs.assertJ)
 }

--- a/ksp/src/main/kotlin/com/tschuchort/compiletesting/Ksp.kt
+++ b/ksp/src/main/kotlin/com/tschuchort/compiletesting/Ksp.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.com.intellij.psi.PsiTreeChangeAdapter
 import org.jetbrains.kotlin.com.intellij.psi.PsiTreeChangeListener
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
@@ -26,6 +27,7 @@ import java.io.File
  * The list of symbol processors for the kotlin compilation.
  * https://goo.gle/ksp
  */
+@OptIn(ExperimentalCompilerApi::class)
 var KotlinCompilation.symbolProcessorProviders: List<SymbolProcessorProvider>
     get() = getKspRegistrar().providers
     set(value) {
@@ -36,12 +38,14 @@ var KotlinCompilation.symbolProcessorProviders: List<SymbolProcessorProvider>
 /**
  * The directory where generated KSP sources are written
  */
+@OptIn(ExperimentalCompilerApi::class)
 val KotlinCompilation.kspSourcesDir: File
     get() = kspWorkingDir.resolve("sources")
 
 /**
  * Arbitrary arguments to be passed to ksp
  */
+@OptIn(ExperimentalCompilerApi::class)
 var KotlinCompilation.kspArgs: MutableMap<String, String>
     get() = getKspRegistrar().options
     set(value) {
@@ -52,6 +56,7 @@ var KotlinCompilation.kspArgs: MutableMap<String, String>
 /**
  * Controls for enabling incremental processing in KSP.
  */
+@OptIn(ExperimentalCompilerApi::class)
 var KotlinCompilation.kspIncremental: Boolean
     get() = getKspRegistrar().incremental
     set(value) {
@@ -62,6 +67,7 @@ var KotlinCompilation.kspIncremental: Boolean
 /**
  * Controls for enabling incremental processing logs in KSP.
  */
+@OptIn(ExperimentalCompilerApi::class)
 var KotlinCompilation.kspIncrementalLog: Boolean
     get() = getKspRegistrar().incrementalLog
     set(value) {
@@ -72,6 +78,7 @@ var KotlinCompilation.kspIncrementalLog: Boolean
 /**
  * Controls for enabling all warnings as errors in KSP.
  */
+@OptIn(ExperimentalCompilerApi::class)
 var KotlinCompilation.kspAllWarningsAsErrors: Boolean
     get() = getKspRegistrar().allWarningsAsErrors
     set(value) {
@@ -83,6 +90,7 @@ var KotlinCompilation.kspAllWarningsAsErrors: Boolean
  * Run processors and compilation in a single compiler invocation if true.
  * See [com.google.devtools.ksp.KspCliOption.WITH_COMPILATION_OPTION].
  */
+@OptIn(ExperimentalCompilerApi::class)
 var KotlinCompilation.kspWithCompilation: Boolean
     get() = getKspRegistrar().withCompilation
     set(value) {
@@ -90,18 +98,22 @@ var KotlinCompilation.kspWithCompilation: Boolean
         registrar.withCompilation = value
     }
 
+@OptIn(ExperimentalCompilerApi::class)
 private val KotlinCompilation.kspJavaSourceDir: File
     get() = kspSourcesDir.resolve("java")
 
+@OptIn(ExperimentalCompilerApi::class)
 private val KotlinCompilation.kspKotlinSourceDir: File
     get() = kspSourcesDir.resolve("kotlin")
 
+@OptIn(ExperimentalCompilerApi::class)
 private val KotlinCompilation.kspResources: File
     get() = kspSourcesDir.resolve("resources")
 
 /**
  * The working directory for KSP
  */
+@OptIn(ExperimentalCompilerApi::class)
 private val KotlinCompilation.kspWorkingDir: File
     get() = workingDir.resolve("ksp")
 
@@ -111,12 +123,14 @@ private val KotlinCompilation.kspWorkingDir: File
 // TODO this seems to be ignored by KSP and it is putting classes into regular classes directory
 //  but we still need to provide it in the KSP options builder as it is required
 //  once it works, we should make the property public.
+@OptIn(ExperimentalCompilerApi::class)
 private val KotlinCompilation.kspClassesDir: File
     get() = kspWorkingDir.resolve("classes")
 
 /**
  * The directory where compiled KSP caches are written
  */
+@OptIn(ExperimentalCompilerApi::class)
 private val KotlinCompilation.kspCachesDir: File
     get() = kspWorkingDir.resolve("caches")
 
@@ -141,6 +155,7 @@ private class KspTestExtension(
 /**
  * Registers the [KspTestExtension] to load the given list of processors.
  */
+@OptIn(ExperimentalCompilerApi::class)
 private class KspCompileTestingComponentRegistrar(
     private val compilation: KotlinCompilation
 ) : ComponentRegistrar {
@@ -221,6 +236,7 @@ private class KspCompileTestingComponentRegistrar(
 /**
  * Gets the test registrar from the plugin list or adds if it does not exist.
  */
+@OptIn(ExperimentalCompilerApi::class)
 private fun KotlinCompilation.getKspRegistrar(): KspCompileTestingComponentRegistrar {
     componentRegistrars.firstIsInstanceOrNull<KspCompileTestingComponentRegistrar>()?.let {
         return it

--- a/ksp/src/main/kotlin/com/tschuchort/compiletesting/Ksp.kt
+++ b/ksp/src/main/kotlin/com/tschuchort/compiletesting/Ksp.kt
@@ -222,10 +222,10 @@ private class KspCompileTestingComponentRegistrar(
  * Gets the test registrar from the plugin list or adds if it does not exist.
  */
 private fun KotlinCompilation.getKspRegistrar(): KspCompileTestingComponentRegistrar {
-    compilerPlugins.firstIsInstanceOrNull<KspCompileTestingComponentRegistrar>()?.let {
+    componentRegistrars.firstIsInstanceOrNull<KspCompileTestingComponentRegistrar>()?.let {
         return it
     }
     val kspRegistrar = KspCompileTestingComponentRegistrar(this)
-    compilerPlugins = compilerPlugins + kspRegistrar
+    componentRegistrars = componentRegistrars + kspRegistrar
     return kspRegistrar
 }

--- a/ksp/src/test/kotlin/com/tschuchort/compiletesting/KspTest.kt
+++ b/ksp/src/test/kotlin/com/tschuchort/compiletesting/KspTest.kt
@@ -8,6 +8,7 @@ import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.mock
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4


### PR DESCRIPTION
- Deprecate `KotlinCompilation.singleModule` option as it no longer exists in kotlinc.
- Propagate `@ExperimentalCompilerApi` annotations
- `KotlinJsCompilation.irOnly` and `KotlinJsCompilation.irProduceJs` now default to true and are the only supported options.
- Expose new `KotlinCompilation.compilerPluginRegistrars` property for adding `CompilerPluginRegistrar` instances (the new entrypoint API for compiler plugins)
  ```kotlin
  KotlinCompilation().apply {
    compilerPluginRegistrars = listOf(MyCompilerPluginRegistrar())
  }
  ```
- Deprecate `KotlinCompilation.compilerPlugins` in favor of `KotlinCompilation.componentRegistrars`. The latter is also deprecated, but this is at least a clearer name.
  ```diff
  KotlinCompilation().apply {
  -  compilerPlugins = listOf(MyComponentRegistrar())
  +  componentRegistrars = listOf(MyComponentRegistrar())
  }
  ```
- Don't try to set removed kotlinc args. If they're removed, they're removed forever. This library will just track latest kotlin releases with its own.
