### PR TITLE
Set resources path when compilerPluginRegistrars not empty.

### DIFF
--- a/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt
@@ -221,8 +221,11 @@ abstract class AbstractKotlinCompilation<A : CommonCompilerArguments> internal c
                      K2 compiler doesn't support plugins yet. This way, users of K2 can prevent MainComponentRegistrar
                      from being loaded and crashing K2 by setting both [componentRegistrars] and [commandLineProcessors] to
                      the emptyList. */
-                    if (componentRegistrars.isNotEmpty() || commandLineProcessors.isNotEmpty())
-                        arrayOf(getResourcesPath())
+                    if (
+                        componentRegistrars.isNotEmpty() ||
+                        compilerPluginRegistrars.isNotEmpty() ||
+                        commandLineProcessors.isNotEmpty()
+                    ) arrayOf(getResourcesPath())
                     else emptyArray()
         }
 


### PR DESCRIPTION
This is fix the problem that the new compilerPluginRegistrars will be ignored when both componentRegistrars and commandLineProcessors are empty.