### PR TITLE
Make useIr enabled by default

### DIFF
--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -73,7 +73,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 	var javaParameters: Boolean = false
 
 	/** Use the IR backend */
-	var useIR: Boolean = false
+	var useIR: Boolean = true
 
 	/** Use the old JVM backend */
 	var useOldBackend: Boolean = false


### PR DESCRIPTION
Despite being `false` by default in `K2JVMCompilerArguments`, it's enabled by default since Kotlin 1.5.0

Resolves #132