### PR TITLE
Prepare for Kotlin 1.9.20

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -28,12 +28,11 @@ dependencies {
     implementation(libs.okio)
     implementation(libs.classgraph)
 
-    // This dependency is only needed as a "sample" compiler plugin to test that
+    // These dependencies are only needed as a "sample" compiler plugin to test that
     // running compiler plugins passed via the pluginClasspath CLI option works
     testRuntimeOnly(libs.kotlin.scriptingCompiler)
-
-    // Include Kotlin/JS standard library in test classpath for auto loading
-    testRuntimeOnly(libs.kotlin.stdlibJs)
+    testRuntimeOnly(libs.intellij.core)
+    testRuntimeOnly(libs.intellij.util)
 
     // The Kotlin compiler should be near the end of the list because its .jar file includes
     // an obsolete version of Guava

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt
@@ -59,7 +59,7 @@ abstract class AbstractKotlinCompilation<A : CommonCompilerArguments> internal c
     /**
      * Legacy [ComponentRegistrar] plugins that should be added to the compilation.
      */
-    @Deprecated("Migrate to ComponentPluginRegistrar and use componentPluginRegistrars instead")
+    @Deprecated("Migrate to ComponentPluginRegistrar and use compilerPluginRegistrars instead")
     var componentRegistrars: List<ComponentRegistrar> = emptyList()
 
     /**
@@ -127,6 +127,9 @@ abstract class AbstractKotlinCompilation<A : CommonCompilerArguments> internal c
 
     /** Enable support for the new K2 compiler. */
     var supportsK2 = false
+
+    /** Disables compiler scripting support. */
+    var disableStandardScript = false
 
     // Directory for input source files
     protected val sourcesDir get() = workingDir.resolve("sources")

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -32,12 +32,14 @@ import org.jetbrains.kotlin.config.Services
 import org.jetbrains.kotlin.kapt3.base.incremental.DeclaredProcType
 import org.jetbrains.kotlin.kapt3.base.incremental.IncrementalProcessor
 import org.jetbrains.kotlin.kapt3.util.MessageCollectorBackedKaptLogger
-import java.io.*
-import java.lang.RuntimeException
+import java.io.File
+import java.io.OutputStreamWriter
 import java.net.URLClassLoader
 import java.nio.file.Path
 import javax.annotation.processing.Processor
-import javax.tools.*
+import javax.tools.Diagnostic
+import javax.tools.DiagnosticCollector
+import javax.tools.JavaFileObject
 
 data class PluginOption(val pluginId: PluginId, val optionName: OptionName, val optionValue: OptionValue)
 

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -72,9 +72,6 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 	/** Generate metadata for Java 1.8 reflection on method parameters */
 	var javaParameters: Boolean = false
 
-	/** Use the IR backend */
-	var useIR: Boolean = true
-
 	/** Use the old JVM backend */
 	var useOldBackend: Boolean = false
 
@@ -294,7 +291,6 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 
 		args.jvmTarget = jvmTarget
 		args.javaParameters = javaParameters
-		args.useIR = useIR
 		args.useOldBackend = useOldBackend
 
 		if(javaModulePath != null)
@@ -337,6 +333,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 
 		args.javaPackagePrefix = javaPackagePrefix
 		args.suppressMissingBuiltinsError = suppressMissingBuiltinsError
+		args.disableStandardScript = disableStandardScript
 	}
 
 	/** Performs the 1st and 2nd compilation step to generate stubs and run annotation processors */

--- a/core/src/test/kotlin/com/tschuchort/compiletesting/CompilerPluginsTest.kt
+++ b/core/src/test/kotlin/com/tschuchort/compiletesting/CompilerPluginsTest.kt
@@ -71,19 +71,5 @@ class CompilerPluginsTest {
 
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
-
-    @Test
-    fun `when JS compiler plugins are added they get executed`() {
-        val mockPlugin = Mockito.mock(ComponentRegistrar::class.java)
-
-        val result = defaultJsCompilerConfig().apply {
-            sources = listOf(SourceFile.new("emptyKotlinFile.kt", ""))
-            componentRegistrars = listOf(mockPlugin)
-            inheritClassPath = true
-        }.compile()
-
-        verify(mockPlugin, atLeastOnce()).registerProjectComponents(any(), any())
-        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-    }
 }
 

--- a/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
+++ b/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
@@ -7,7 +7,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
 import org.jetbrains.kotlin.compiler.plugin.CliOption
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
-import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
@@ -912,6 +911,8 @@ class KotlinCompilationTests {
 			componentRegistrars = emptyList()
 			pluginClasspaths = emptyList()
 			languageVersion = "2.0"
+			inheritClassPath = true
+			disableStandardScript = true
 		}.compile()
 
 		assertThat(result.exitCode).isEqualTo(ExitCode.OK)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin = "1.9.10"
-ksp = "1.9.10-1.0.13"
+kotlin = "1.9.20-Beta"
+ksp = "1.9.20-Beta-1.0.13"
 
 [plugins]
 buildconfig = { id = "com.github.gmazzo.buildconfig", version = "3.1.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 idea = "222.4459.24" # Flamingo | 2022.2.1 (see https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html)
-kotlin = "1.9.20-Beta"
-ksp = "1.9.20-Beta-1.0.13"
+kotlin = "1.9.20"
+ksp = "1.9.20-1.0.13"
 
 [plugins]
 buildconfig = { id = "com.github.gmazzo.buildconfig", version = "3.1.0" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-dokka = { id = "org.jetbrains.dokka", version = "1.9.0" }
+dokka = { id = "org.jetbrains.dokka", version = "1.9.10" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.25.3" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+idea = "222.4459.24" # Flamingo | 2022.2.1 (see https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html)
 kotlin = "1.9.20-Beta"
 ksp = "1.9.20-Beta-1.0.13"
 
@@ -15,12 +16,14 @@ autoService-ksp = "dev.zacsweers.autoservice:auto-service-ksp:1.1.0"
 
 classgraph = "io.github.classgraph:classgraph:4.8.162"
 
+intellij-core = { module = "com.jetbrains.intellij.platform:core", version.ref = "idea" }
+intellij-util = { module = "com.jetbrains.intellij.platform:util", version.ref = "idea" }
+
 javapoet = "com.squareup:javapoet:1.13.0"
 
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-annotationProcessingEmbeddable = { module = "org.jetbrains.kotlin:kotlin-annotation-processing-embeddable", version.ref = "kotlin" }
 kotlin-scriptingCompiler = { module = "org.jetbrains.kotlin:kotlin-scripting-compiler", version.ref = "kotlin" }
-kotlin-stdlibJs = { module = "org.jetbrains.kotlin:kotlin-stdlib-js", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,7 +37,7 @@ dependencyResolutionManagement {
 
         google()
 
-        // Kotlin bootstrap repository, useful for testing against Kotlin dev builds. Usually only tested on CI shadow jobs
+        // Kotlin dev repository, useful for testing against Kotlin dev builds. Usually only tested on CI shadow jobs
         // https://kotlinlang.slack.com/archives/C0KLZSCHF/p1616514468003200?thread_ts=1616509748.001400&cid=C0KLZSCHF
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/") {
             name = "Kotlin-Dev"
@@ -45,6 +45,14 @@ dependencyResolutionManagement {
                 // this repository *only* contains Kotlin artifacts (don't try others here)
                 includeGroupByRegex("org\\.jetbrains.*")
             }
+        }
+
+        maven("https://www.jetbrains.com/intellij-repository/releases") {
+            name = "Intellij"
+        }
+
+        maven("https://cache-redirector.jetbrains.com/intellij-dependencies") {
+            name = "Intellij"
         }
     }
 }


### PR DESCRIPTION
- Removes legacy JS support. JS IR not supported currently
- Remove `useIR` property
- Add `disableStandardScript` property