### PR TITLE
Create parent directories of SourceFile

### DIFF
--- a/core/src/main/kotlin/com/tschuchort/compiletesting/SourceFile.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/SourceFile.kt
@@ -36,6 +36,7 @@ abstract class SourceFile {
         fun new(name: String, contents: String) = object : SourceFile() {
             override fun writeIfNeeded(dir: File): File {
                 val file = dir.resolve(name)
+                file.parentFile.mkdirs()
                 file.createNewFile()
 
                 file.sink().buffer().use {

--- a/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
+++ b/core/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationTests.kt
@@ -93,6 +93,18 @@ class KotlinCompilationTests {
 	}
 
 	@Test
+	fun `runs with sources in directory`() {
+		val result = defaultCompilerConfig().apply {
+			sources = listOf(SourceFile.kotlin("com/foo/bar/kSource.kt", """ 
+					package com.foo.bar
+					class KSource"""))
+		}.compile()
+
+		assertThat(result.exitCode).isEqualTo(ExitCode.OK)
+		assertClassLoadable(result, "com.foo.bar.KSource")
+	}
+
+	@Test
 	fun `Kotlin can access JDK`() {
 		val source = SourceFile.kotlin("kSource.kt", """
             import javax.lang.model.SourceVersion


### PR DESCRIPTION
This is just a cherry-pick from this PR: https://github.com/tschuchortdev/kotlin-compile-testing/pull/339

Fixes #188

Original message:

Currently, createNewFile() fails if you have a SourceFile in a directory, since it can't create the owning directory.