### PR TITLE
Cleanup old sources between compilations

### DIFF
--- a/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt
@@ -247,7 +247,7 @@ abstract class AbstractKotlinCompilation<A : CommonCompilerArguments> internal c
                     /* __HACK__: The Kotlin compiler expects at least one Kotlin source file or it will crash,
                        so we trick the compiler by just including an empty .kt-File. We need the compiler to run
                        even if there are no Kotlin files because some compiler plugins may also process Java files. */
-                    listOf(SourceFile.new("emptyKotlinFile.kt", "").writeIfNeeded(sourcesDir).absolutePath)
+                    listOf(SourceFile.new("emptyKotlinFile.kt", "").writeTo(sourcesDir).absolutePath)
                 } else {
                     emptyList()
                 }

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -559,6 +559,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
   /** Runs the compilation task */
   fun compile(): JvmCompilationResult {
     // make sure all needed directories exist
+    sourcesDir.deleteRecursively()
     sourcesDir.mkdirs()
     classesDir.mkdirs()
     kaptSourceDir.mkdirs()
@@ -567,7 +568,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
     kaptKotlinGeneratedDir.mkdirs()
 
     // write given sources to working directory
-    val sourceFiles = sources.map { it.writeIfNeeded(sourcesDir) }
+    val sourceFiles = sources.map { it.writeTo(sourcesDir) }
 
     pluginClasspaths.forEach { filepath ->
       if (!filepath.exists()) {

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinJsCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinJsCompilation.kt
@@ -86,11 +86,12 @@ class KotlinJsCompilation : AbstractKotlinCompilation<K2JSCompilerArguments>() {
   /** Runs the compilation task */
   fun compile(): JsCompilationResult {
     // make sure all needed directories exist
+    sourcesDir.deleteRecursively()
     sourcesDir.mkdirs()
     outputDir.mkdirs()
 
     // write given sources to working directory
-    val sourceFiles = sources.map { it.writeIfNeeded(sourcesDir) }
+    val sourceFiles = sources.map { it.writeTo(sourcesDir) }
 
     pluginClasspaths.forEach { filepath ->
       if (!filepath.exists()) {

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/SourceFile.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/SourceFile.kt
@@ -9,7 +9,7 @@ import org.intellij.lang.annotations.Language
  * A source file for the [KotlinCompilation]
  */
 abstract class SourceFile {
-    internal abstract fun writeIfNeeded(dir: File): File
+    internal abstract fun writeTo(dir: File): File
 
     companion object {
         /**
@@ -34,7 +34,7 @@ abstract class SourceFile {
          * Create a new source file for the compilation when the compilation is run
          */
         fun new(name: String, contents: String) = object : SourceFile() {
-            override fun writeIfNeeded(dir: File): File {
+            override fun writeTo(dir: File): File {
                 val file = dir.resolve(name)
                 file.parentFile.mkdirs()
                 file.createNewFile()
@@ -50,12 +50,13 @@ abstract class SourceFile {
         /**
          * Compile an existing source file
          */
+        @Deprecated("This will not work reliably with KSP, use `new` instead")
         fun fromPath(path: File) = object : SourceFile() {
             init {
                 require(path.isFile)
             }
 
-            override fun writeIfNeeded(dir: File): File = path
+            override fun writeTo(dir: File): File = path
         }
     }
 }

--- a/ksp/src/main/kotlin/com/tschuchort/compiletesting/Ksp.kt
+++ b/ksp/src/main/kotlin/com/tschuchort/compiletesting/Ksp.kt
@@ -117,6 +117,12 @@ var KotlinCompilation.kspLoggingLevels: Set<CompilerMessageSeverity>
     tool.loggingLevels = value
   }
 
+@ExperimentalCompilerApi
+val JvmCompilationResult.sourcesGeneratedBySymbolProcessor: Sequence<File>
+  get() = outputDirectory.parentFile.resolve("ksp/sources")
+    .walkTopDown()
+    .filter { it.isFile }
+
 @OptIn(ExperimentalCompilerApi::class)
 internal val KotlinCompilation.kspJavaSourceDir: File
   get() = kspSourcesDir.resolve("java")


### PR DESCRIPTION
This is required since KSP accepts a list of source directories while Kotlin accepts a list of source files. This means that if you compile multiple times, removing a source file between, KSP will still process the removed files.