### PR TITLE
Support Kotlin 2.1.0-Beta1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 idea = "242.8057" # (see https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html)
-kotlin = "2.0.10"
+kotlin = "2.1.0-Beta1"
 kotlinpoet = "1.18.1"
-ksp = "2.0.10-1.0.24"
+ksp = "2.0.20-1.0.25"
 
 [plugins]
 buildconfig = { id = "com.github.gmazzo.buildconfig", version = "3.1.0" }


### PR DESCRIPTION
The class CLITool was renamed to CLICompiler and CommonToolArguments to CommonCompilerArguments that cause a MethodNotFoundException at runtime when using kct 0.5.1 with 2.1.0-Beta1.