### PR TITLE
Update Kotlin to 2.2.0

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
 
     api(libs.kotlin.compilerEmbeddable)
     api(libs.kotlin.annotationProcessingEmbeddable)
-    api(libs.kotlin.kapt4)
 
     testImplementation(libs.kotlinpoet)
     testImplementation(libs.javapoet)

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.Services
-import org.jetbrains.kotlin.kapt3.base.KaptOptions
+import org.jetbrains.kotlin.kapt.base.KaptOptions
 import org.jetbrains.kotlin.util.ServiceLoaderLite
 
 /**

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/DiagnosticMessage.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/DiagnosticMessage.kt
@@ -35,6 +35,7 @@ public data class DiagnosticMessage(
 internal fun CompilerMessageSeverity.toSeverity() = when (this) {
     CompilerMessageSeverity.EXCEPTION,
     CompilerMessageSeverity.ERROR -> DiagnosticSeverity.ERROR
+    CompilerMessageSeverity.FIXED_WARNING,
     CompilerMessageSeverity.STRONG_WARNING,
     CompilerMessageSeverity.WARNING -> DiagnosticSeverity.WARNING
     CompilerMessageSeverity.INFO -> DiagnosticSeverity.INFO

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KctKaptCompilerPluginRegistrar.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KctKaptCompilerPluginRegistrar.kt
@@ -1,75 +1,59 @@
-/*
- * Copyright 2010-2016 JetBrains s.r.o.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+package com.facebook.buck.jvm.java.javax.com.tschuchort.compiletesting
 
-package com.tschuchort.compiletesting
-
-import java.io.File
-import org.jetbrains.kotlin.analyzer.AnalysisResult
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
+import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoot
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
 import org.jetbrains.kotlin.cli.jvm.config.JavaSourceRoot
 import org.jetbrains.kotlin.cli.jvm.config.JvmClasspathRoot
-import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project
-import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
+import org.jetbrains.kotlin.config.CommonConfigurationKeys.USE_FIR
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
-import org.jetbrains.kotlin.container.ComponentProvider
-import org.jetbrains.kotlin.context.ProjectContext
-import org.jetbrains.kotlin.descriptors.ModuleDescriptor
-import org.jetbrains.kotlin.extensions.StorageComponentContainerContributor
-import org.jetbrains.kotlin.kapt.AbstractKaptExtension
+import org.jetbrains.kotlin.fir.extensions.FirAnalysisHandlerExtension
+import org.jetbrains.kotlin.kapt.FirKaptAnalysisHandlerExtension
+import org.jetbrains.kotlin.kapt.KAPT_OPTIONS
 import org.jetbrains.kotlin.kapt.base.AptMode
 import org.jetbrains.kotlin.kapt.base.Kapt
 import org.jetbrains.kotlin.kapt.base.KaptFlag
 import org.jetbrains.kotlin.kapt.base.KaptOptions
-import org.jetbrains.kotlin.kapt.base.logString
 import org.jetbrains.kotlin.kapt.base.LoadedProcessors
 import org.jetbrains.kotlin.kapt.base.incremental.IncrementalProcessor
+import org.jetbrains.kotlin.kapt.base.logString
 import org.jetbrains.kotlin.kapt.base.util.KaptLogger
 import org.jetbrains.kotlin.kapt.util.MessageCollectorBackedKaptLogger
-import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.resolve.BindingTrace
-import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
-import org.jetbrains.kotlin.kapt.KaptComponentRegistrar as KotlinKaptComponentRegistrar
 
 @ExperimentalCompilerApi
-internal class KaptComponentRegistrar(
+internal class KctKaptCompilerPluginRegistrar(
     private val processors: List<IncrementalProcessor>,
     private val kaptOptions: KaptOptions.Builder
-) : ComponentRegistrar {
+) : CompilerPluginRegistrar() {
+    override val supportsK2 = true
 
-    override fun registerProjectComponents(project: MockProject, configuration: CompilerConfiguration) {
+    override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
+        if (!configuration.getBoolean(USE_FIR)) return
+
         if (processors.isEmpty())
             return
 
         val contentRoots = configuration[CLIConfigurationKeys.CONTENT_ROOTS] ?: emptyList()
 
         val optionsBuilder = kaptOptions.apply {
-            projectBaseDir = project.basePath?.let(::File)
+//            projectBaseDir = project.basePath?.let(::File)
             compileClasspath.addAll(contentRoots.filterIsInstance<JvmClasspathRoot>().map { it.file })
             javaSourceRoots.addAll(contentRoots.filterIsInstance<JavaSourceRoot>().map { it.file })
             classesOutputDir = classesOutputDir ?: configuration.get(JVMConfigurationKeys.OUTPUT_DIRECTORY)
         }
 
         val messageCollector = configuration.get(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY)
-            ?: PrintingMessageCollector(System.err, MessageRenderer.PLAIN_FULL_PATHS, optionsBuilder.flags.contains(KaptFlag.VERBOSE))
+            ?: PrintingMessageCollector(
+                System.err,
+                MessageRenderer.PLAIN_FULL_PATHS,
+                optionsBuilder.flags.contains(KaptFlag.VERBOSE)
+            )
 
         val logger = MessageCollectorBackedKaptLogger(
             optionsBuilder.flags.contains(KaptFlag.VERBOSE),
@@ -77,7 +61,8 @@ internal class KaptComponentRegistrar(
             messageCollector
         )
 
-        if (!optionsBuilder.checkOptions(project, logger, configuration)) {
+        fun abortAnalysis() = FirAnalysisHandlerExtension.Companion.registerExtension(AbortAnalysisHandlerExtension())
+        if (!optionsBuilder.checkOptions(logger, configuration, ::abortAnalysis)) {
             return
         }
 
@@ -89,24 +74,27 @@ internal class KaptComponentRegistrar(
             logger.info(options.logString())
         }
 
-        val kaptAnalysisCompletedHandlerExtension =
-            object : AbstractKaptExtension(options, logger, configuration) {
+        val kaptFirAnalysisCompletedHandlerExtension =
+            object : FirKaptAnalysisHandlerExtension(logger) {
+                override fun isApplicable(configuration: CompilerConfiguration): Boolean {
+                    configuration.put(KAPT_OPTIONS, optionsBuilder)
+                    optionsBuilder.processingClasspath
+                    return configuration.getBoolean(USE_FIR)
+                }
                 override fun loadProcessors() = LoadedProcessors(
                     processors = processors,
                     classLoader = this::class.java.classLoader
                 )
-        }
+            }
 
-        AnalysisHandlerExtension.registerExtension(project, kaptAnalysisCompletedHandlerExtension)
-        StorageComponentContainerContributor.registerExtension(
-            project = project,
-            extension = KotlinKaptComponentRegistrar.KaptComponentContributor(kaptAnalysisCompletedHandlerExtension)
-        )
+        FirAnalysisHandlerExtension.registerExtension(kaptFirAnalysisCompletedHandlerExtension)
     }
 
-    private fun KaptOptions.Builder.checkOptions(project: MockProject, logger: KaptLogger, configuration: CompilerConfiguration): Boolean {
-        fun abortAnalysis() = AnalysisHandlerExtension.registerExtension(project, AbortAnalysisHandlerExtension())
-
+    private fun KaptOptions.Builder.checkOptions(
+        logger: KaptLogger,
+        configuration: CompilerConfiguration,
+        abortAnalysis: () -> Unit
+    ): Boolean {
         if (classesOutputDir == null) {
             if (configuration.get(JVMConfigurationKeys.OUTPUT_JAR) != null) {
                 logger.error("Kapt does not support specifying JAR file outputs. Please specify the classes output directory explicitly.")
@@ -146,26 +134,9 @@ internal class KaptComponentRegistrar(
     /* This extension simply disables both code analysis and code generation.
      * When aptOnly is true, and any of required kapt options was not passed, we just abort compilation by providing this extension.
      * */
-    private class AbortAnalysisHandlerExtension : AnalysisHandlerExtension {
-        override fun doAnalysis(
-            project: Project,
-            module: ModuleDescriptor,
-            projectContext: ProjectContext,
-            files: Collection<KtFile>,
-            bindingTrace: BindingTrace,
-            componentProvider: ComponentProvider
-        ): AnalysisResult? {
-            return AnalysisResult.success(bindingTrace.bindingContext, module, shouldGenerateCode = false)
-        }
-
-        override fun analysisCompleted(
-            project: Project,
-            module: ModuleDescriptor,
-            bindingTrace: BindingTrace,
-            files: Collection<KtFile>
-        ): AnalysisResult? {
-            return AnalysisResult.success(bindingTrace.bindingContext, module, shouldGenerateCode = false)
-        }
+    private class AbortAnalysisHandlerExtension : FirAnalysisHandlerExtension() {
+        override fun doAnalysis(project: Project, configuration: CompilerConfiguration) = true
+        override fun isApplicable(configuration: CompilerConfiguration) = true
     }
 
 }

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -32,13 +32,13 @@ import org.jetbrains.kotlin.config.JVMAssertionsMode
 import org.jetbrains.kotlin.config.JvmDefaultMode
 import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.Services
-import org.jetbrains.kotlin.kapt3.base.AptMode
-import org.jetbrains.kotlin.kapt3.base.KaptFlag
-import org.jetbrains.kotlin.kapt3.base.KaptOptions
-import org.jetbrains.kotlin.kapt3.base.incremental.DeclaredProcType
-import org.jetbrains.kotlin.kapt3.base.incremental.IncrementalProcessor
-import org.jetbrains.kotlin.kapt3.util.MessageCollectorBackedKaptLogger
-import org.jetbrains.kotlin.kapt4.Kapt4CompilerPluginRegistrar
+import org.jetbrains.kotlin.kapt.KaptCompilerPluginRegistrar
+import org.jetbrains.kotlin.kapt.base.AptMode
+import org.jetbrains.kotlin.kapt.base.KaptFlag
+import org.jetbrains.kotlin.kapt.base.KaptOptions
+import org.jetbrains.kotlin.kapt.base.incremental.DeclaredProcType
+import org.jetbrains.kotlin.kapt.base.incremental.IncrementalProcessor
+import org.jetbrains.kotlin.kapt.util.MessageCollectorBackedKaptLogger
 
 data class PluginOption(
   val pluginId: PluginId,
@@ -248,6 +248,8 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
   val kaptIncrementalDataDir
     get() = kaptBaseDir.resolve("incrementalData")
 
+  var processingClasspaths: List<File> = emptyList()
+
   /** ExitCode of the entire Kotlin compilation process */
   enum class ExitCode {
     OK,
@@ -337,6 +339,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
         it.sourcesOutputDir = kaptSourceDir
         it.incrementalDataOutputDir = kaptIncrementalDataDir
         it.classesOutputDir = classesDir
+        it.processingClasspath += commonClasspaths()
         it.processingOptions.apply {
           putAll(kaptArgs)
           putIfAbsent(OPTION_KAPT_KOTLIN_GENERATED, kaptKotlinGeneratedDir.absolutePath)
@@ -387,7 +390,7 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
 
     val isK2 = useKapt4()
     if (isK2) {
-      this.compilerPluginRegistrars += Kapt4CompilerPluginRegistrar()
+      this.compilerPluginRegistrars += KaptCompilerPluginRegistrar()
       this.kotlincArguments += kaptOptions.toPluginOptions()
     }
 

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinCompilation.kt
@@ -339,7 +339,9 @@ class KotlinCompilation : AbstractKotlinCompilation<K2JVMCompilerArguments>() {
         it.sourcesOutputDir = kaptSourceDir
         it.incrementalDataOutputDir = kaptIncrementalDataDir
         it.classesOutputDir = classesDir
-        it.processingClasspath += commonClasspaths()
+        if(inheritClassPath) {
+          it.processingClasspath += hostClasspaths
+        }
         it.processingOptions.apply {
           putAll(kaptArgs)
           putIfAbsent(OPTION_KAPT_KOTLIN_GENERATED, kaptKotlinGeneratedDir.absolutePath)

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinJsCompilation.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/KotlinJsCompilation.kt
@@ -56,15 +56,7 @@ class KotlinJsCompilation : AbstractKotlinCompilation<K2JSCompilerArguments>() {
 
   // setup common arguments for the two kotlinc calls
   private fun jsArgs() = commonArguments(K2JSCompilerArguments()) { args ->
-    // the compiler should never look for stdlib or reflect in the
-    // kotlinHome directory (which is null anyway). We will put them
-    // in the classpath manually if they're needed
-    args.noStdlib = true
-
     args.moduleKind = "commonjs"
-    outputFileName?.let {
-      args.outputFile = File(outputDir, it).absolutePath
-    }
     args.outputDir = outputDir.absolutePath
     args.sourceMapBaseDirs = jsClasspath().joinToString(separator = File.pathSeparator)
     args.libraries = listOfNotNull(kotlinStdLibJsJar).joinToString(separator = ":")

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/MainComponentRegistrar.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/MainComponentRegistrar.kt
@@ -16,6 +16,7 @@
 @file:Suppress("DEPRECATION")
 package com.tschuchort.compiletesting
 
+import com.facebook.buck.jvm.java.javax.com.tschuchort.compiletesting.KctKaptCompilerPluginRegistrar
 import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
@@ -23,8 +24,8 @@ import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CommonConfigurationKeys.USE_FIR
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.kapt3.base.KaptOptions
-import org.jetbrains.kotlin.kapt3.base.incremental.IncrementalProcessor
+import org.jetbrains.kotlin.kapt.base.KaptOptions
+import org.jetbrains.kotlin.kapt.base.incremental.IncrementalProcessor
 
 @ExperimentalCompilerApi
 @AutoService(ComponentRegistrar::class, CompilerPluginRegistrar::class)
@@ -51,6 +52,10 @@ internal class MainComponentRegistrar : ComponentRegistrar, CompilerPluginRegist
       with(pluginRegistrar) {
         registerExtensions(configuration)
       }
+    }
+
+    with(KctKaptCompilerPluginRegistrar(parameters.processors, parameters.kaptOptions)) {
+      registerExtensions(configuration)
     }
   }
 

--- a/core/src/main/kotlin/com/tschuchort/compiletesting/kapt/util.kt
+++ b/core/src/main/kotlin/com/tschuchort/compiletesting/kapt/util.kt
@@ -2,8 +2,8 @@ package com.tschuchort.compiletesting.kapt
 
 import java.io.File
 import org.jetbrains.kotlin.kapt.cli.KaptCliOption
-import org.jetbrains.kotlin.kapt3.base.KaptFlag
-import org.jetbrains.kotlin.kapt3.base.KaptOptions
+import org.jetbrains.kotlin.kapt.base.KaptFlag
+import org.jetbrains.kotlin.kapt.base.KaptOptions
 
 fun KaptOptions.Builder.toPluginOptions(): List<String> {
     val options = mutableListOf<String>()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 idea = "251.25410.159" # (see https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html)
-kotlin = "2.1.10"
+kotlin = "2.2.0"
 kotlinpoet = "2.2.0"
-ksp = "2.1.10-1.0.29"
+ksp = "2.2.0-2.0.2"
 
 [plugins]
 buildconfig = { id = "com.github.gmazzo.buildconfig", version = "3.1.0" }
@@ -24,7 +24,6 @@ javapoet = "com.squareup:javapoet:1.13.0"
 
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-annotationProcessingEmbeddable = { module = "org.jetbrains.kotlin:kotlin-annotation-processing-embeddable", version.ref = "kotlin" }
-kotlin-kapt4 = { module = "org.jetbrains.kotlin:kotlin-annotation-processing-compiler", version.ref = "kotlin" }
 kotlin-scriptingCompiler = { module = "org.jetbrains.kotlin:kotlin-scripting-compiler", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }


### PR DESCRIPTION
- Updates Kotlin and KSP to 2.2.0
- Removed the "kapt4" artifact as it seems like it isn't being maintained in 2.2.0+ ([Maven Central](https://central.sonatype.com/artifact/org.jetbrains.kotlin/kotlin-annotation-processing-compiler/versions), [KT-70797](https://youtrack.jetbrains.com/issue/KT-70797))
- The `kapt3` package was folded into `kapt` ([KT-70804](https://youtrack.jetbrains.com/issue/KT-70804))
- Created `KctKaptCompilerPluginRegistrar` to provide similar functionality as `KaptComponentRegistrar` which is needed for 2.2.0 since `ComponentRegistrar` doesn't work with FIR analysis
-  Provide a `processingClasspath` to `KaptOptions` since FIR analysis requires it
    - I believe this just needs the classpath of the processors being used, but I couldn't find a more fine-grained approach to that, so I just reused `commonClasspaths`